### PR TITLE
Fix e2e assertion for home page

### DIFF
--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -3,6 +3,6 @@
 describe('My First Test', () => {
   it('Visits the app root url', () => {
     cy.visit('/')
-    cy.contains('h1', 'Welcome to Your Vue.js App')
+    cy.contains('h1', 'Dividends FIRE')
   })
 })


### PR DESCRIPTION
## Summary
- update Cypress test to look for the proper heading on the home page

## Testing
- `yarn test:e2e --headless` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c691f608333be30b215ffdb475b