### PR TITLE
Fix outdated tests

### DIFF
--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -3,6 +3,6 @@
 describe('My First Test', () => {
   it('Visits the app root url', () => {
     cy.visit('/')
-    cy.contains('h1', 'Welcome to Your Vue.js App')
+    cy.contains('h2', 'When can I retire with dividend growth investing?')
   })
 })

--- a/tests/unit/example.spec.js
+++ b/tests/unit/example.spec.js
@@ -1,12 +1,9 @@
 import { shallowMount } from '@vue/test-utils'
-import HelloWorld from '@/components/HelloWorld.vue'
+import Menu from '@/components/Menu.vue'
 
-describe('HelloWorld.vue', () => {
-  it('renders props.msg when passed', () => {
-    const msg = 'new message'
-    const wrapper = shallowMount(HelloWorld, {
-      props: { msg }
-    })
-    expect(wrapper.text()).toMatch(msg)
+describe('Menu.vue', () => {
+  it('renders the site title', () => {
+    const wrapper = shallowMount(Menu)
+    expect(wrapper.text()).toContain('Dividends FIRE')
   })
 })


### PR DESCRIPTION
## Summary
- update unit test to use `Menu` component
- update Cypress test to check for home page text

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm run test:unit` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ada0f688333835acfcc129966fc